### PR TITLE
readme: fix sitemap typing in robots example

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,14 +84,14 @@ const robotsTxt = generateRobotsTxt([
 		allow: ['/'],
 		disallow: ['/admin', '/login'],
 		crawlDelay: 1,
-		sitemap: 'https://example.com/sitemap.xml'
+		sitemap: ['https://example.com/sitemap.xml']
 	},
 	{
 		userAgent: 'Googlebot',
 		allow: ['/'],
 		disallow: ['/admin', '/login'],
 		crawlDelay: 1,
-		sitemap: 'https://example.com/sitemap.xml'
+		sitemap: ['https://example.com/sitemap.xml']
 	}
 ]
 );


### PR DESCRIPTION
Readme example currently does not match the type.